### PR TITLE
Make content-type display names pretty

### DIFF
--- a/server/content-types/payment.js
+++ b/server/content-types/payment.js
@@ -3,7 +3,7 @@ module.exports = {
     tableName: "StrapiStripePayment",
     singularName: "strapi-stripe-payment", // kebab-case mandatory
     pluralName: "strapi-stripe-payments", // kebab-case mandatory
-    displayName: "StrapiStripePayment",
+    displayName: "Payment",
     description: "Stripe Payment",
     kind: "collectionType",
   },

--- a/server/content-types/product.js
+++ b/server/content-types/product.js
@@ -3,7 +3,7 @@ module.exports = {
     tableName: "StrapiStripeProduct",
     singularName: "strapi-stripe-product", // kebab-case mandatory
     pluralName: "strapi-stripe-products", // kebab-case mandatory
-    displayName: "StrapiStripeProduct",
+    displayName: "Product",
     description: "Stripe Products",
     kind: "collectionType",
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18726788/170770394-1c2eba36-7eca-4890-9ed7-f8c865a600c5.png)

A comparison of the difference for only one of the display fields.

![image](https://user-images.githubusercontent.com/18726788/170776233-a44e6c6f-2e38-439c-a0c1-d4bd27cadf7f.png)

After making pretty displayNames.

If you are having trouble updating, search the strapi local directory to discover where that displayName: is located. The following command searches current directory to which you execute the command in.

```grep -R "StrapiStripePayment" .``` 
