### PR TITLE
fix issue #31 (undefined extensions path)

### DIFF
--- a/server/register.js
+++ b/server/register.js
@@ -18,8 +18,8 @@ async function generateJs() {
   const filledJsData = _.template(jsData)({
     backendUrl: strapi.config.server.url,
   });
-
-  const bbbJsPath = path.resolve(strapi.dirs.extensions, 'strapi-stripe', 'public', 'stripe.js');
+  const extensionsPath = strapi.dirs.extensions || strapi.dirs.dist.extensions;
+  const bbbJsPath = path.resolve(extensionsPath, 'strapi-stripe', 'public', 'stripe.js');
   await fs.ensureFile(bbbJsPath);
   await fs.writeFile(bbbJsPath, filledJsData);
 }


### PR DESCRIPTION
When i try to install the plugin there is an error (The "path" argument must be of type string. Received undefined) threw on the register file. It was reported on issue #31 .

This pull request fixes that issue by getting the path from `strapi.dirs.dist.extensions` if `strapi.dirs.extensions` is undefined.

Idk if the verification is needed, but as i cannot test this change in other environments (i'm running windows 11) i kept the previous version as a fallback