### PR TITLE
optional null value for callbackUrl

### DIFF
--- a/server/services/stripeService.js
+++ b/server/services/stripeService.js
@@ -191,6 +191,10 @@ module.exports = ({ strapi }) => ({
   async sendDataToCallbackUrl(session) {
     try {
       const stripeSettings = await this.initialize();
+      
+      // Return if no callbackUrl is set
+      if (!stripeSettings.callbackUrl) return;
+      
       await axiosInstance.post(stripeSettings.callbackUrl, session);
     } catch (error) {
       throw new ApplicationError(error.message);


### PR DESCRIPTION
sendDataToCallbackUrl fails when stripeSettings.callbackUrl is null. It is not required in the admin panel, so should take this into account.